### PR TITLE
fix: remove project tile capitalization

### DIFF
--- a/index.html
+++ b/index.html
@@ -643,7 +643,7 @@ layout: default
 															<div class="elementor-element elementor-element-852fd4a elementor-widget elementor-widget-text-editor" data-id="852fd4a" data-element_type="widget" data-widget_type="text-editor.default">
 																<div class="elementor-widget-container">
 																	<div class="elementor-text-editor elementor-clearfix">
-																		<h2 class="elementor-heading-title elementor-size-default elementor-inline-editing pen" style="color: #ffffff; font-family: Montserrat, sans-serif; word-spacing: 0px; font-weight: 400; text-transform: capitalize; line-height: 1.4em; font-size: 15px; text-align: center;" data-elementor-setting-key="title" data-pen-placeholder="Type Here...">Financial Data Warehouse Which Aggregates Over <br />31 000 Time Series Into A Few Hundred Charts For <br />A Fintech Company From London</h2>
+																		<h2 class="elementor-heading-title elementor-size-default elementor-inline-editing pen" style="color: #ffffff; font-family: Montserrat, sans-serif; word-spacing: 0px; font-weight: 400; text-transform: none; line-height: 1.4em; font-size: 15px; text-align: center;">financial data warehouse which aggregates over <br />31 000 time series into a few hundred charts for <br />a fintech company from London</h2>
 																	</div>
 																</div>
 															</div>
@@ -655,7 +655,7 @@ layout: default
 														<div class="elementor-widget-wrap">
 															<div class="elementor-element elementor-element-6993570 elementor-widget elementor-widget-heading" data-id="6993570" data-element_type="widget" data-widget_type="heading.default">
 																<div class="elementor-widget-container">
-																	<h2 class="elementor-heading-title elementor-size-default">graph data search/visualization system for auditors/investigators from the Netherlands</h2>
+																	<h2 class="elementor-heading-title elementor-size-default" style="text-transform: none;">graph data search/visualization system for auditors/investigators from the Netherlands</h2>
 																</div>
 															</div>
 														</div>
@@ -672,7 +672,7 @@ layout: default
 														<div class="elementor-widget-wrap">
 															<div class="elementor-element elementor-element-062331f elementor-widget elementor-widget-heading" data-id="062331f" data-element_type="widget" data-widget_type="heading.default">
 																<div class="elementor-widget-container">
-																	<h2 class="elementor-heading-title elementor-size-default">super scalable WAF optimized down to extremely low running costs for a client from Chicago, IL
+																	<h2 class="elementor-heading-title elementor-size-default" style="text-transform: none;">super scalable WAF optimized down to extremely low running costs for a client from Chicago, IL
 																	</h2>
 																</div>
 															</div>
@@ -684,7 +684,7 @@ layout: default
 														<div class="elementor-widget-wrap">
 															<div class="elementor-element elementor-element-e1dc759 elementor-widget elementor-widget-heading" data-id="e1dc759" data-element_type="widget" data-widget_type="heading.default">
 																<div class="elementor-widget-container">
-																	<h2 class="elementor-heading-title elementor-size-default">multisource cloud object synthesizer library for a storage provider from San Mateo, CA
+																	<h2 class="elementor-heading-title elementor-size-default" style="text-transform: none;">multisource cloud object synthesizer library for a storage provider from San Mateo, CA
 																	</h2>
 																</div>
 															</div>
@@ -696,7 +696,7 @@ layout: default
 														<div class="elementor-widget-wrap">
 															<div class="elementor-element elementor-element-c5cde07 elementor-widget elementor-widget-heading" data-id="c5cde07" data-element_type="widget" data-widget_type="heading.default">
 																<div class="elementor-widget-container">
-																	<h2 class="elementor-heading-title elementor-size-default">report generator/inventory tracker for an e-commerce/healthcare company from Canada</h2>
+																	<h2 class="elementor-heading-title elementor-size-default" style="text-transform: none;">report generator/inventory tracker for an e-commerce/healthcare company from Canada</h2>
 																</div>
 															</div>
 														</div>
@@ -713,7 +713,7 @@ layout: default
 														<div class="elementor-widget-wrap">
 															<div class="elementor-element elementor-element-66078c3 elementor-widget elementor-widget-heading" data-id="66078c3" data-element_type="widget" data-widget_type="heading.default">
 																<div class="elementor-widget-container">
-																	<h2 class="elementor-heading-title elementor-size-default">k8s-based revenue optimizer for large private GPU compute clusters in North America
+																	<h2 class="elementor-heading-title elementor-size-default" style="text-transform: none;">k8s-based revenue optimizer for large private GPU compute clusters in North America
 																	</h2>
 																</div>
 															</div>
@@ -725,7 +725,7 @@ layout: default
 														<div class="elementor-widget-wrap">
 															<div class="elementor-element elementor-element-221a461 elementor-widget elementor-widget-heading" data-id="221a461" data-element_type="widget" data-widget_type="heading.default">
 																<div class="elementor-widget-container">
-																	<h2 class="elementor-heading-title elementor-size-default">paper product level tracker for toilet cleaners from Canada</h2>
+																	<h2 class="elementor-heading-title elementor-size-default" style="text-transform: none;">paper product level tracker for toilet cleaners from Canada</h2>
 																</div>
 															</div>
 														</div>
@@ -736,7 +736,7 @@ layout: default
 														<div class="elementor-widget-wrap">
 															<div class="elementor-element elementor-element-04b3bcc elementor-widget elementor-widget-heading" data-id="04b3bcc" data-element_type="widget" data-widget_type="heading.default">
 																<div class="elementor-widget-container">
-																	<h2 class="elementor-heading-title elementor-size-default">hydrant certification report generator for Australian plumbers</h2>
+																	<h2 class="elementor-heading-title elementor-size-default" style="text-transform: none;">hydrant certification report generator for Australian plumbers</h2>
 																</div>
 															</div>
 														</div>
@@ -753,7 +753,7 @@ layout: default
 														<div class="elementor-widget-wrap">
 															<div class="elementor-element elementor-element-0d5bb7a elementor-widget elementor-widget-heading" data-id="0d5bb7a" data-element_type="widget" data-widget_type="heading.default">
 																<div class="elementor-widget-container">
-																	<h2 class="elementor-heading-title elementor-size-default">multi-tenant hospitality management system for large properties in the US
+																	<h2 class="elementor-heading-title elementor-size-default" style="text-transform: none;">multi-tenant hospitality management system for large properties in the US
 																	</h2>
 																</div>
 															</div>
@@ -765,7 +765,7 @@ layout: default
 														<div class="elementor-widget-wrap">
 															<div class="elementor-element elementor-element-19cfbb6 elementor-widget elementor-widget-heading" data-id="19cfbb6" data-element_type="widget" data-widget_type="heading.default">
 																<div class="elementor-widget-container">
-																	<h2 class="elementor-heading-title elementor-size-default">large scale information display system for retailers (international)</h2>
+																	<h2 class="elementor-heading-title elementor-size-default" style="text-transform: none;">large scale information display system for retailers (international)</h2>
 																</div>
 															</div>
 														</div>


### PR DESCRIPTION
Currently it looks like this:

![image](https://github.com/user-attachments/assets/33bd8458-5e15-4ee9-879a-1c9f4951c284)
